### PR TITLE
feat: Update pyhf image to release v0.6.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: neubauergroup/bluewaters-pyhf
         dockerfile: pyhf/Dockerfile
-        tags: latest,0.5.4
+        tags: latest,0.6.1
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
@@ -31,5 +31,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: neubauergroup/bluewaters-pyhf
         dockerfile: pyhf/Dockerfile
-        tags: latest,latest-stable,0.5.4
+        tags: latest,latest-stable,0.6.1
         tag_with_ref: true

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,5 @@ image-pyhf:
 	docker build . \
 		--pull \
 		--file pyhf/Dockerfile \
-		--build-arg PYHF_RELEASE=0.5.4 \
+		--build-arg PYHF_RELEASE=0.6.1 \
 		--tag neubauergroup/bluewaters-pyhf:debug-local

--- a/pyhf/Dockerfile
+++ b/pyhf/Dockerfile
@@ -4,7 +4,7 @@ RUN yum update -y && \
     yum install -y \
         python3
 
-ARG PYHF_RELEASE=0.5.4
+ARG PYHF_RELEASE=0.6.1
 RUN python3 -m pip install --upgrade pip setuptools wheel && \
     python3 -m pip install "pyhf[xmlio,contrib]==${PYHF_RELEASE}" && \
     python3 -m pip list


### PR DESCRIPTION
Update Docker image to use `pyhf` `v0.6.1`

```
* Use pyhf v0.6.1 in Docker image
   - c.f. https://github.com/scikit-hep/pyhf/releases/tag/v0.6.1
```