### PR TITLE
fix: Use lowercase repo name for Docker tags in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,7 +68,6 @@ jobs:
 
       - name: lowercase test
         run: |
-          echo ${{ github.repository,, }}
           echo ${{ steps.prep.outputs.repo_name_lowercase }}
 
       - name: Test build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,7 +67,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: lowercase test
-        run: echo ${{ github.repository,, }}
+        run: |
+          echo ${{ github.repository,, }}
+          echo ${{ steps.prep.outputs.repo_name_lowercase }}
 
       - name: Test build
         id: docker_build_test

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,6 +64,9 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: lowercase test
+        run: echo ${{ github.repository,, }}
+
       - name: Test build
         id: docker_build_test
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,6 +30,8 @@ jobs:
         run: |
           DOCKER_IMAGE=neubauergroup/bluewaters-pyhf
           VERSION=latest
+          REPO_NAME=${{github.repository}}
+          REPO_NAME_LOWERCASE="${REPO_NAME,,}"
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
           elif [[ $GITHUB_REF == refs/pull/* ]]; then
@@ -39,13 +41,12 @@ jobs:
           TAGS="$TAGS,${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:0.6.1,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
           # Releases also have GITHUB_REFs that are tags, so reuse VERSION
           if [ "${{ github.event_name }}" = "release" ]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${{github.repository}}:latest-stable,ghcr.io/${{github.repository}}:${VERSION}"
+            TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${REPO_NAME_LOWERCASE}:latest-stable,ghcr.io/${REPO_NAME_LOWERCASE}:${VERSION}"
           fi
-          REPO_NAME=${{github.repository}}
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo ::set-output name=repo_name_lowercase::"${REPO_NAME,,}"
+          echo ::set-output name=repo_name_lowercase::"${REPO_NAME_LOWERCASE}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -104,7 +105,7 @@ jobs:
         with:
           context: .
           file: pyhf/Dockerfile
-          tags: neubauergroup/bluewaters-pyhf:latest,neubauergroup/bluewaters-pyhf:0.6.1,ghcr.io/${{github.repository}}:latest,ghcr.io/${{github.repository}}:0.6.1
+          tags: neubauergroup/bluewaters-pyhf:latest,neubauergroup/bluewaters-pyhf:0.6.1,ghcr.io/${{steps.prep.outputs.repo_name_lowercase}}:latest,ghcr.io/${{steps.prep.outputs.repo_name_lowercase}}:0.6.1
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,10 +67,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: lowercase test
-        run: |
-          echo ${{ steps.prep.outputs.repo_name_lowercase }}
-
       - name: Test build
         id: docker_build_test
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,9 +41,11 @@ jobs:
           if [ "${{ github.event_name }}" = "release" ]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${{github.repository}}:latest-stable,ghcr.io/${{github.repository}}:${VERSION}"
           fi
+          REPO_NAME=${{github.repository}}
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo ::set-output name=repo_name_lowercase::"${REPO_NAME,,}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
Docker tags are all lowercase, so any use of the GitHub repoistory name in a Docker tag must be lowercased to work.

```
* Lowercase GitHub repo name to use as part of a Docker tag
* Amends PR #6 
```