### PR TITLE
feat: Use neubauergroup/centos-python3 for base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,6 @@ image-pyhf:
 	docker build . \
 		--pull \
 		--file pyhf/Dockerfile \
-		--build-arg PYTHON_VERSION=3.8.8 \
+		--build-arg BASE_IMAGE=neubauergroup/centos-python3:3.8.8 \
 		--build-arg PYHF_RELEASE=0.6.1 \
 		--tag neubauergroup/bluewaters-pyhf:debug-local

--- a/pyhf/Dockerfile
+++ b/pyhf/Dockerfile
@@ -1,35 +1,5 @@
-FROM centos:7
-
-RUN yum update -y && \
-    yum install -y \
-        gcc \
-        openssl-devel \
-        bzip2-devel \
-        libffi-devel \
-        lzma-devel \
-        curl \
-        tar \
-        make && \
-    yum clean all
-
-ARG PYTHON_VERSION=3.8.8
-WORKDIR /build
-RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz" && \
-    tar -xzf "Python-${PYTHON_VERSION}.tgz" && \
-    cd "Python-${PYTHON_VERSION}" && \
-    ./configure --help && \
-    ./configure --prefix=/usr \
-        --exec_prefix=/usr \
-        --with-ensurepip \
-        --enable-optimizations \
-        --with-lto \
-        --enable-ipv6 && \
-    make -j"$(($(nproc) - 1))" && \
-    make install && \
-    printf "\nalias python='python3'\n" >> ~/.bashrc && \
-    cd / && \
-    rm -rf /build
-WORKDIR /
+ARG BASE_IMAGE=neubauergroup/centos-python3:3.8.8
+FROM ${BASE_IMAGE} as base
 
 ARG PYHF_RELEASE=0.6.1
 RUN python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \


### PR DESCRIPTION
```
* Use neubauergroup/centos-python3:3.8.8 as the base image
* Reduces build time and separates out the CPython dependency
```