### PR TITLE
Update to latest funcx-endpoint lib

### DIFF
--- a/pyhf/Dockerfile
+++ b/pyhf/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE} as base
 ARG PYHF_RELEASE=0.6.1
 RUN python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python3 -m pip --no-cache-dir install "pyhf[xmlio,contrib]==${PYHF_RELEASE}" && \
-    python3 -m pip --no-cache-dir install funcx-endpoint && \
+    python3 -m pip --no-cache-dir install "funcx-endpoint>=0.2.3" && \
     python3 -m pip list
 
 ENV LC_ALL=en_US.UTF-8


### PR DESCRIPTION
Just a little tweak to force a rebuild of the Docker image with the latest version of the funcx-endpoint lib