### PR TITLE
feat: Update base image to use Python 3.8.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,6 @@ image-pyhf:
 	docker build . \
 		--pull \
 		--file pyhf/Dockerfile \
-		--build-arg BASE_IMAGE=neubauergroup/centos-python3:3.8.8 \
+		--build-arg BASE_IMAGE=neubauergroup/centos-python3:3.8.10 \
 		--build-arg PYHF_RELEASE=0.6.1 \
 		--tag neubauergroup/bluewaters-pyhf:debug-local

--- a/pyhf/Dockerfile
+++ b/pyhf/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=neubauergroup/centos-python3:3.8.8
+ARG BASE_IMAGE=neubauergroup/centos-python3:3.8.10
 FROM ${BASE_IMAGE} as base
 
 ARG PYHF_RELEASE=0.6.1


### PR DESCRIPTION
```
* Update base image to neubauergroup/centos-python3:3.8.10
   - Uses CPython v3.8.10
   - c.f. https://www.python.org/downloads/release/python-3810/
```