### PR TITLE
fix: Create all mg5_aMC tool directories during image build

### DIFF
--- a/mg5_amc/Dockerfile
+++ b/mg5_amc/Dockerfile
@@ -1,4 +1,9 @@
 ARG BASE_IMAGE=scailfin/madgraph5-amc-nlo-centos:mg5_amc3.1.0
 FROM ${BASE_IMAGE} as base
 
-RUN lhapdf get NNPDF23_lo_as_0130_qed
+WORKDIR /home/docker/data
+
+RUN echo 'exit' > exit && \
+    mg5_aMC exit && \
+    rm exit && \
+    lhapdf get NNPDF23_lo_as_0130_qed

--- a/mg5_amc/Dockerfile
+++ b/mg5_amc/Dockerfile
@@ -1,9 +1,5 @@
 ARG BASE_IMAGE=scailfin/madgraph5-amc-nlo-centos:mg5_amc3.1.0
 FROM ${BASE_IMAGE} as base
 
-WORKDIR /home/docker/data
-
-RUN echo 'exit' > exit && \
-    mg5_aMC exit && \
-    rm exit && \
+RUN echo "exit" | mg5_aMC && \
     lhapdf get NNPDF23_lo_as_0130_qed


### PR DESCRIPTION
* Resolves #14 
* Resolves #15 

Shifter on Blue Waters puts containers in a read-only file system meaning that writing anything inside the container directory hierarchy that isn't explicitly mounted to a volume on the user's Blue Waters file area isn't allowed. As the first invocation of `mg5_aMC` in a new `MG5_aMC` directory creates directories for tools if they don't exist yet, running `mg5_aMC` for the _first time_ in Shifter will produce an error

```pytb
OSError: [Errno 30] Read-only file system: '/usr/local/MG5_aMC/Template/LO/Source/make_opts'
```

To fix this, simply run `mg5_aMC` during the image build process so that these directories will exist and be usable at container runtime in Shifter.

```
* Run mg5_aMC during image build to create directory structure for all MadGraph5 tooling under /usr/local/MG5_aMC
   - Te first invocation of mg5_aMC in a new working directory creates directories for tools if they don't exist yet
   - This is necessary for use with Shifter on Blue Waters, as Shifter puts the container in a read-only file system
   - If a directory is not volume mounted to the user's file system on Blue Waters explicitly, writing to an area in the container will cause an OSError and exit the runtime with a failure
```