### PR TITLE
feat: Update pyhf image to use pyhf v0.6.2

### DIFF
--- a/.github/workflows/docker-pyhf.yml
+++ b/.github/workflows/docker-pyhf.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           DOCKER_IMAGE=neubauergroup/bluewaters-pyhf
           VERSION=latest
-          PYHF_VERSION=0.6.1
+          PYHF_VERSION=0.6.2
           REPO_NAME=${{github.repository}}
           REPO_NAME_LOWERCASE="${REPO_NAME,,}"
           if [[ $GITHUB_REF == refs/tags/* ]]; then

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ image-pyhf:
 	docker build . \
 		--pull \
 		--file pyhf/Dockerfile \
-		--build-arg BASE_IMAGE=neubauergroup/centos-python3:3.8.10 \
-		--build-arg PYHF_RELEASE=0.6.1 \
+		--build-arg BASE_IMAGE=neubauergroup/centos-python3:3.8.11 \
+		--build-arg PYHF_RELEASE=0.6.2 \
 		--tag neubauergroup/bluewaters-pyhf:debug-local
 
 image-momemta:

--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ All Docker images are publicly available on the [Neubauer Group Docker Hub org](
 
 - [`neubauergroup/bluewaters-pyhf`](https://hub.docker.com/r/neubauergroup/bluewaters-pyhf)
 - [`neubauergroup/bluewaters-mg5_amc`](https://hub.docker.com/r/neubauergroup/bluewaters-mg5_amc)
+- [`neubauergroup/bluewaters-momemta`](https://hub.docker.com/r/neubauergroup/bluewaters-momemta)
+- [`scailfin/delphes-python-centos`](https://hub.docker.com/r/scailfin/delphes-python-centos)

--- a/pyhf/Dockerfile
+++ b/pyhf/Dockerfile
@@ -1,8 +1,9 @@
-ARG BASE_IMAGE=neubauergroup/centos-python3:3.8.10
+ARG BASE_IMAGE=neubauergroup/centos-python3:3.8.11
 FROM ${BASE_IMAGE} as base
 
-ARG PYHF_RELEASE=0.6.1
+ARG PYHF_RELEASE=0.6.2
 RUN python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
+    python3 -m pip --no-cache-dir install "click<8.0" && \
     python3 -m pip --no-cache-dir install "pyhf[xmlio,contrib]==${PYHF_RELEASE}" && \
     python3 -m pip --no-cache-dir install "funcx-endpoint>=0.2.3" && \
     python3 -m pip list


### PR DESCRIPTION
```
* Update neubauergroup/bluewaters-pyhf image to use pyhf v0.6.2
   - Use click<8.0 to avoid CLI issues
   - Use CPython 3.8.11 base image neubauergroup/centos-python3:3.8.11
* Add links to MoMEMta and Delphes compatible images in README
```