### PR TITLE
feat: Install Click in MadGraph5 Docker image

### DIFF
--- a/mg5_amc/Dockerfile
+++ b/mg5_amc/Dockerfile
@@ -3,4 +3,5 @@ FROM ${BASE_IMAGE} as base
 
 RUN echo "exit" | mg5_aMC && \
     lhapdf get NNPDF23_lo_as_0130_qed && \
-    python -m pip --no-cache-dir install click~=8.0.1
+    python -m pip --no-cache-dir install click~=8.0.1 && \
+    python -m pip list

--- a/mg5_amc/Dockerfile
+++ b/mg5_amc/Dockerfile
@@ -2,4 +2,5 @@ ARG BASE_IMAGE=scailfin/madgraph5-amc-nlo-centos:mg5_amc3.1.1
 FROM ${BASE_IMAGE} as base
 
 RUN echo "exit" | mg5_aMC && \
-    lhapdf get NNPDF23_lo_as_0130_qed
+    lhapdf get NNPDF23_lo_as_0130_qed && \
+    python -m pip --no-cache-dir install click~=8.0.1


### PR DESCRIPTION
To have access to CLI tools on Blue Waters, install Click in the image before

```
* Add installation of Click Python library to MadGraph5 Docker image
```